### PR TITLE
Update python version from 3.5.2 to 3.7.5

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.7.5


### PR DESCRIPTION
Update python version from 3.5.2 to 3.7.5, to work correctly with Scalingo deployment since the new default stack [scalingo-18](https://scalingo.com/articles/2019/08/06/multiple-stacks.html) was added.